### PR TITLE
Fix error in print.cpp in displaying target time

### DIFF
--- a/print.cpp
+++ b/print.cpp
@@ -203,11 +203,11 @@ void generate_report (const runStruct *pRun)
   , pRun->longitude
   );
   
-  strftime (buffer, 80, "%d-%b-%Y", &nowTm);
+  strftime (buffer, 80, "%d-%b-%Y", &targetTm);
   printf
   ("                       Date: %s\n", buffer);
 
-  strftime (buffer, 80, "%Z", &nowTm);
+  strftime (buffer, 80, "%Z", &targetTm);
   printf
   ("                   Timezone: %s\n", buffer);
 


### PR DESCRIPTION
The "nowTm" struct was being used for the target time data in report even though "targetTm" was already being created/populated. 

The end result was that the "Target Time" was always the local time and not a time specified... see below for the *before* example. 

```
$ ./sunwait report y 20 m 12 d 1 35.0N 120.0W
...
Target Information ...

                   Location:  ...........
                       Date: 09-Feb-2020
                   Timezone: MST
   Sun directly north/south: 12:42
             Twilight angle: -0.83 degrees (daylight)
```