### PR TITLE
Fix for make clean error, if the folder was already deleted or not yet created

### DIFF
--- a/makefile
+++ b/makefile
@@ -21,6 +21,6 @@ $(EXECUTABLE): $(OBJECTS)
 	$(C) $(CFLAGS) $< -o $@
 
 clean:
-	rm *.o sunwait
+	rm -f *.o sunwait
 
 


### PR DESCRIPTION
I ran into that problem while using ansible to build sunwait. To be sure that everything is clean, I called `make clean` even before the first install (because I use the same script for install as for updates). Which ran into an error due to the non-existance of the sunwait folder. Adding `-f` ignores, if a folder was already removed.