### PR TITLE
Fix build errors on osx

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,13 +2,15 @@
 #
 # 08/12/2014  IFC  0.6  No changes since 0.5
 # 02/05/2015  IFC  0.7  No changes since 0.5, still
+# 10/03/2020  TLJ  0.9  Move headers to fix build on osx
 #
 
 
 C=gcc
 CFLAGS=-c -Wall 
 LDFLAGS= -lm -lstdc++
-SOURCES=sunwait.cpp sunriset.cpp print.cpp sunwait.h sunriset.h print.h
+SOURCES=sunwait.cpp sunriset.cpp print.cpp
+HEADERS=sunwait.h sunriset.h print.h
 OBJECTS=$(SOURCES:.cpp=.o)
 EXECUTABLE=sunwait
 

--- a/sunriset.cpp
+++ b/sunriset.cpp
@@ -92,7 +92,7 @@ void sunriset (const runStruct *pRun, targetStruct *pTarget)
   /* compute the diurnal arc that the sun traverses to reach the specified altitide altit: */
   double cost = (sind(altitude) - sind(pRun->latitude) * sind(sdec)) / (cosd(pRun->latitude) * cosd(sdec));
 
-  if (abs(cost) < 1.0)
+  if (abs(int(cost)) < 1.0)
     diurnalArc = 2*acosd(cost)/15.0;    /* Diurnal arc, hours */
   else if (cost>=1.0)
     diurnalArc =  0.0; // Polar Night

--- a/sunwait.cpp
+++ b/sunwait.cpp
@@ -19,6 +19,7 @@ const double VERSION=0.8; // <<<<<<<<< CHANGE ME
 // IFC  2014-12-08  0.6  Add timezone handling for output - if required
 // IFC  2015-04-29  0.7  Timezone and DST fixes - and for date line timings
 // IFC  2015-05-27  0.8  Resolve 'dodgy day' and cleanup
+// TLJ  2020-10-03  0.9  Fix build on osx
 //
 
 #include <stdio.h>
@@ -34,7 +35,7 @@ const double VERSION=0.8; // <<<<<<<<< CHANGE ME
 #endif
 
 // Linux
-#if defined __linux__
+#if defined __linux__ || defined __APPLE__
   #include <unistd.h>
 #endif
 
@@ -395,7 +396,7 @@ void myUtcTime (const time_t *pTimet, struct tm *pTm)
     /* Windows code: End */
 
     /* Linux code: Start */
-      #if defined __linux__
+      #if defined __linux__ || defined __APPLE__
         gmtime_r (pTimet, pTm);
       #endif
     /* Linux code: End */
@@ -415,7 +416,7 @@ void myLocalTime (const time_t *pTimet, struct tm *pTm)
     /* Windows code: End */
 
     /* Linux code: Start */
-      #if defined __linux__
+      #if defined __linux__ || defined __APPLE__
         localtime_r (pTimet, pTm);
       #endif
     /* Linux code: End */
@@ -477,7 +478,7 @@ double getUtcBiasHours (const time_t *pTimet)
   /* Windows code: End */
 
   /* Linux code: Start */
-  #if defined __linux__
+  #if defined __linux__ || defined __APPLE__
     char buffer [80];
     signed long int tmpLong = 0;
 
@@ -1130,7 +1131,7 @@ int wait (const runStruct *pRun)
   /* Windows code: End */
 
   /* Linux code: Start */
-  #if defined __linux__
+  #if defined __linux__ || defined __APPLE__
     sleep (waitSeconds);    // Linux-only (seconds OK)
   #endif
   /* Linux code: End */

--- a/sunwait.h
+++ b/sunwait.h
@@ -14,7 +14,7 @@
 #define DEFAULT_LIST      1           /* in 'List' mode, report these number days */
 #define DEFAULT_ANGLE     0.83        /* Default twighlight angle. */
 #define DEFAULT_LATITUDE  40.108306
-#define DEFAULT_LONGITUDE 271.7405121 /* 814 W Daniel St, Champaign, IL, USA */
+#define DEFAULT_LONGITUDE 271.7427 /* South Side School, Champaign, IL, USA */
 
 #define boolean bool
 #define NOT_SET 9999999

--- a/sunwait.h
+++ b/sunwait.h
@@ -13,8 +13,8 @@
 
 #define DEFAULT_LIST      1           /* in 'List' mode, report these number days */
 #define DEFAULT_ANGLE     0.83        /* Default twighlight angle. */
-#define DEFAULT_LATITUDE  52.952308 
-#define DEFAULT_LONGITUDE 359.048052  /* The Buttercross, Bingham, England */
+#define DEFAULT_LATITUDE  40.108306
+#define DEFAULT_LONGITUDE 271.7405121 /* 814 W Daniel St, Champaign, IL, USA */
 
 #define boolean bool
 #define NOT_SET 9999999


### PR DESCRIPTION
`__linux__` is not defined on OSX, but `__APPLE__` is.  I edited the #ifdefs to refelct his.

On osx, clang fails with:
`
gcc sunwait.o sunriset.o print.o sunwait.h sunriset.h print.h -o sunwait -lm -lstdc++
clang: error: cannot specify -o when generating multiple output files
`

This is because clang does not need the header files present in the build command.

I edited the makefile to reflect this.

References:
https://trac.macports.org/ticket/51700#comment:9
https://stackoverflow.com/a/43527114

