### PR TITLE
Fix unused computed valued warning during sunwait.cpp compile.

### DIFF
--- a/sunwait.cpp
+++ b/sunwait.cpp
@@ -662,7 +662,7 @@ int main (int argc, char *argv[])
     if (pRun->debug == ONOFF_ON) printf ("Debug: argv[%d]: >%s<\n", i, arg);
 
     // Strip any hyphen from arguments, but not negative signs of numbers
-    if (arg[0] == '-' && arg[1] != '\0' && !isdigit(arg[1])) *arg++;
+    if (arg[0] == '-' && arg[1] != '\0' && !isdigit(arg[1])) memmove(arg, arg + 1, sizeof arg - 1);
 
     // Normal help or version info
          if   (!strcmp (arg, "v")             ||


### PR DESCRIPTION
Current code generates the following warning during compile:
```
sunwait.cpp: In function ‘int main(int, char**)’:
sunwait.cpp:665:62: warning: value computed is not used [-Wunused-value]
  665 |     if (arg[0] == '-' && arg[1] != '\0' && !isdigit(arg[1])) *arg++;
      |                                                              ^~~~~~
```

This PR changes method of removing '-' in front of command line arguments such that it no longer generates an unused computed value warning.