### PR TITLE
Fix use of C++ make variables.

### DIFF
--- a/makefile
+++ b/makefile
@@ -6,9 +6,8 @@
 #
 
 
-C=gcc
-CFLAGS=-c -Wall 
-LDFLAGS= -lm -lstdc++
+CXXFLAGS=-Wall
+LDFLAGS= -lm
 SOURCES=sunwait.cpp sunriset.cpp print.cpp
 HEADERS=sunwait.h sunriset.h print.h
 OBJECTS=$(SOURCES:.cpp=.o)
@@ -17,10 +16,7 @@ EXECUTABLE=sunwait
 all: $(SOURCES) $(EXECUTABLE)
 	
 $(EXECUTABLE): $(OBJECTS)
-	$(C) $(OBJECTS) -o $@ $(LDFLAGS)
-
-.cpp.o:
-	$(C) $(CFLAGS) $< -o $@
+	$(CXX) $(OBJECTS) -o $@ $(LDFLAGS)
 
 clean:
 	rm -f *.o sunwait

--- a/sunwait.cpp
+++ b/sunwait.cpp
@@ -704,9 +704,9 @@ int main (int argc, char *argv[])
                !strcmp (arg, "noutc"))        pRun->utc = ONOFF_OFF;
 
     // Debug mode
-    else if   (!strcmp (arg, "debug"))        ||
-               !strcmp (arg, "--debug"))      ||
-               !strcmp (arg, "--verbose"))    ||
+    else if   (!strcmp (arg, "debug")         ||
+               !strcmp (arg, "--debug")       ||
+               !strcmp (arg, "--verbose")     ||
                !strcmp (arg, "-v"))           pRun->debug = ONOFF_ON;
     else if   (!strcmp (arg, "nodebug"))      pRun->debug = ONOFF_OFF;
 


### PR DESCRIPTION
Since this is a C++ program, use $(CXX) (which defaults to c++) instead of $(C) (which is currently hardcoded to gcc). This eliminates the need to hardcode linkage of a C++ standard library, which helps on platforms where libc++ is the standard library instead of libstdc++.

This builds on pull request #34, which fixes compiler errors.