### PR TITLE
Fix/sunwait typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 *.i*86
 *.x86_64
 *.hex
+sunwait
 
 # Debug files
 *.dSYM/

--- a/sunwait.cpp
+++ b/sunwait.cpp
@@ -704,9 +704,9 @@ int main (int argc, char *argv[])
                !strcmp (arg, "noutc"))        pRun->utc = ONOFF_OFF;
 
     // Debug mode
-    else if   (!strcmp (arg, "debug"))        ||
-               !strcmp (arg, "--debug"))      ||
-               !strcmp (arg, "--verbose"))    ||
+    else if   (!strcmp (arg, "debug")         ||
+               !strcmp (arg, "--debug")       ||
+               !strcmp (arg, "--verbose")     ||
                !strcmp (arg, "-v"))           pRun->debug = ONOFF_ON;
     else if   (!strcmp (arg, "nodebug"))      pRun->debug = ONOFF_OFF;
 


### PR DESCRIPTION
Remove 3 parentheses that caused the compilation to fail.
Add sunwait binary to .gitignore